### PR TITLE
Handle null response schemas with JAX-RS Response object

### DIFF
--- a/src/main/java/ru/ilb/openapiutils/generator/OpenAPISpecFilterImpl.java
+++ b/src/main/java/ru/ilb/openapiutils/generator/OpenAPISpecFilterImpl.java
@@ -119,6 +119,16 @@ public class OpenAPISpecFilterImpl implements OpenAPISpecFilter {
 //            }
         }
 
+        final MediaType anyMediaType = response.getContent().get("multipart/form-data");
+        if (anyMediaType != null) {
+            if (anyMediaType.getSchema() == null) {
+                final Schema schema = new Schema();
+                schema.setType("string");
+                schema.setFormat("binary");
+                anyMediaType.setSchema(schema);
+            }
+        }
+
         return Optional.of(response);
     }
 


### PR DESCRIPTION
```java
@GET
@Produces("multipart/form-data")
Response download(); 
```
openapi генерит JAX-RS Response в качестве ответа так:

```json
"responses" : {
    "default" : {
         "description" : "default response",
         "content" : {
             "multipart/form-data" : { }
          }
     }
}
```
Используя такой файл для генерации js api, получаем следующий код:

```javascript
var returnType = null;
return this.apiClient.callApi('GET', returnType ...);
```
В качестве возвращаемого типа получается null, который потом используется для сериализации ответа на запрос:

```javascript
var data = _this3.deserialize(response, returnType);
```
Соответсвенно, ответ всегда будет null